### PR TITLE
상속 관계 매핑 테스트

### DIFF
--- a/src/main/java/com/example/jpabookshop/domain/item/Album.java
+++ b/src/main/java/com/example/jpabookshop/domain/item/Album.java
@@ -6,7 +6,6 @@ import jakarta.persistence.PrimaryKeyJoinColumn;
 import lombok.Getter;
 
 @Entity
-@DiscriminatorValue("A")
 @Getter
 public class Album extends Item {
 

--- a/src/main/java/com/example/jpabookshop/domain/item/Album.java
+++ b/src/main/java/com/example/jpabookshop/domain/item/Album.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 @Entity
 @DiscriminatorValue("A")
 @Getter
-@PrimaryKeyJoinColumn(name = "ALBUM_ID")
 public class Album extends Item {
 
     private String artist;

--- a/src/main/java/com/example/jpabookshop/domain/item/Album.java
+++ b/src/main/java/com/example/jpabookshop/domain/item/Album.java
@@ -2,11 +2,13 @@ package com.example.jpabookshop.domain.item;
 
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import jakarta.persistence.PrimaryKeyJoinColumn;
 import lombok.Getter;
 
 @Entity
 @DiscriminatorValue("A")
 @Getter
+@PrimaryKeyJoinColumn(name = "ALBUM_ID")
 public class Album extends Item {
 
     private String artist;

--- a/src/main/java/com/example/jpabookshop/domain/item/Book.java
+++ b/src/main/java/com/example/jpabookshop/domain/item/Book.java
@@ -10,7 +10,6 @@ import lombok.Setter;
 @DiscriminatorValue("B")
 @Getter
 @Setter
-@PrimaryKeyJoinColumn(name = "BOOK_ID")
 public class Book extends Item {
 
     private String author;

--- a/src/main/java/com/example/jpabookshop/domain/item/Book.java
+++ b/src/main/java/com/example/jpabookshop/domain/item/Book.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Entity
-@DiscriminatorValue("B")
 @Getter
 @Setter
 public class Book extends Item {

--- a/src/main/java/com/example/jpabookshop/domain/item/Book.java
+++ b/src/main/java/com/example/jpabookshop/domain/item/Book.java
@@ -2,6 +2,7 @@ package com.example.jpabookshop.domain.item;
 
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import jakarta.persistence.PrimaryKeyJoinColumn;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,6 +10,7 @@ import lombok.Setter;
 @DiscriminatorValue("B")
 @Getter
 @Setter
+@PrimaryKeyJoinColumn(name = "BOOK_ID")
 public class Book extends Item {
 
     private String author;

--- a/src/main/java/com/example/jpabookshop/domain/item/Item.java
+++ b/src/main/java/com/example/jpabookshop/domain/item/Item.java
@@ -16,7 +16,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Entity
-@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn(name  = "DTYPE")
 @Getter
 @Setter

--- a/src/main/java/com/example/jpabookshop/domain/item/Item.java
+++ b/src/main/java/com/example/jpabookshop/domain/item/Item.java
@@ -16,8 +16,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Entity
-@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
-@DiscriminatorColumn(name  = "DTYPE")
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
 @Getter
 @Setter
 public abstract class Item {

--- a/src/main/java/com/example/jpabookshop/domain/item/Item.java
+++ b/src/main/java/com/example/jpabookshop/domain/item/Item.java
@@ -16,7 +16,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Entity
-@Inheritance(strategy = InheritanceType.JOINED)
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name  = "DTYPE")
 @Getter
 @Setter

--- a/src/main/java/com/example/jpabookshop/domain/item/Movie.java
+++ b/src/main/java/com/example/jpabookshop/domain/item/Movie.java
@@ -6,7 +6,6 @@ import jakarta.persistence.PrimaryKeyJoinColumn;
 import lombok.Getter;
 
 @Entity
-@DiscriminatorValue("M")
 @Getter
 public class Movie extends Item {
 

--- a/src/main/java/com/example/jpabookshop/domain/item/Movie.java
+++ b/src/main/java/com/example/jpabookshop/domain/item/Movie.java
@@ -8,8 +8,6 @@ import lombok.Getter;
 @Entity
 @DiscriminatorValue("M")
 @Getter
-@PrimaryKeyJoinColumn(name = "MOVIE_ID")
-
 public class Movie extends Item {
 
     private String director;

--- a/src/main/java/com/example/jpabookshop/domain/item/Movie.java
+++ b/src/main/java/com/example/jpabookshop/domain/item/Movie.java
@@ -2,11 +2,14 @@ package com.example.jpabookshop.domain.item;
 
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import jakarta.persistence.PrimaryKeyJoinColumn;
 import lombok.Getter;
 
 @Entity
 @DiscriminatorValue("M")
 @Getter
+@PrimaryKeyJoinColumn(name = "MOVIE_ID")
+
 public class Movie extends Item {
 
     private String director;

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,2 @@
+spring.application.name=jpa-book-shop
+spring.jpa.properties.hibernate.show_sql=true

--- a/src/test/java/com/example/jpabookshop/service/InheritanceTest.java
+++ b/src/test/java/com/example/jpabookshop/service/InheritanceTest.java
@@ -36,10 +36,14 @@ public class InheritanceTest {
 
         /*
           inheritance joined 인 경우엔 쿼리가 다음과 같이 발생한다.
-          Hibernate: insert into item (name,price,stock_quantity,dtype,item_id) values (?,?,?,'B',?)
-          Hibernate: insert into book (author,isbn,book_id) values (?,?,?)
+          insert into item (name,price,stock_quantity,dtype,item_id) values (?,?,?,'B',?)
+          insert into book (author,isbn,book_id) values (?,?,?)
          */
 
+        /*
+          inheritance single_table 인 경우엔 쿼리가 다음과 같이 발생한다.
+          insert into item (name,price,stock_quantity,author,isbn,dtype,item_id) values (?,?,?,?,?,'B',?)
+         */
     }
 
     @Test
@@ -59,6 +63,13 @@ public class InheritanceTest {
            left join movie i1_3
             on i1_0.item_id=i1_3.movie_id
             where i1_0.item_id=?
+         */
+
+        /*
+          inheritance single_table 인 경우엔 쿼리가 다음과 같이 발생한다.
+          select i1_0.item_id,i1_0.dtype,i1_0.name,i1_0.price,i1_0.stock_quantity,i1_0.artist,i1_0.etc,i1_0.author,i1_0.isbn,i1_0.actor,i1_0.director
+          from item i1_0
+          where i1_0.item_id=?
          */
 
         assertEquals("책 1", foundItem.getName());

--- a/src/test/java/com/example/jpabookshop/service/InheritanceTest.java
+++ b/src/test/java/com/example/jpabookshop/service/InheritanceTest.java
@@ -44,6 +44,11 @@ public class InheritanceTest {
           inheritance single_table 인 경우엔 쿼리가 다음과 같이 발생한다.
           insert into item (name,price,stock_quantity,author,isbn,dtype,item_id) values (?,?,?,?,?,'B',?)
          */
+
+        /*
+          inheritance table_per_class 인 경우엔 쿼리가 다음과 같이 발생한다.
+          insert into book (name,price,stock_quantity,author,isbn,item_id) values (?,?,?,?,?,?)
+         */
     }
 
     @Test
@@ -70,6 +75,21 @@ public class InheritanceTest {
           select i1_0.item_id,i1_0.dtype,i1_0.name,i1_0.price,i1_0.stock_quantity,i1_0.artist,i1_0.etc,i1_0.author,i1_0.isbn,i1_0.actor,i1_0.director
           from item i1_0
           where i1_0.item_id=?
+         */
+
+        /*
+          inheritance table_per_class 인 경우엔 쿼리가 다음과 같이 발생한다.
+          elect i1_0.item_id,i1_0.clazz_,i1_0.name,i1_0.price,i1_0.stock_quantity,i1_0.artist,i1_0.etc,i1_0.author,i1_0.isbn,i1_0.actor,i1_0.director
+          from
+            (select price, stock_quantity, item_id, artist, etc, name, null as author, null as isbn, null as actor, null as director, 1 as clazz_
+              from album
+              union all
+             select price, stock_quantity, item_id, null as artist, null as etc, name, author, isbn, null as actor, null as director, 2 as clazz_
+               from book
+              union all
+             select price, stock_quantity, item_id, null as artist, null as etc, name, null as author, null as isbn, actor, director, 3 as clazz_
+               from movie) i1_0
+           where i1_0.item_id=?
          */
 
         assertEquals("책 1", foundItem.getName());

--- a/src/test/java/com/example/jpabookshop/service/InheritanceTest.java
+++ b/src/test/java/com/example/jpabookshop/service/InheritanceTest.java
@@ -1,0 +1,76 @@
+package com.example.jpabookshop.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.example.jpabookshop.domain.Address;
+import com.example.jpabookshop.domain.Member;
+import com.example.jpabookshop.domain.item.Book;
+import com.example.jpabookshop.domain.item.Item;
+import com.example.jpabookshop.repository.ItemRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+public class InheritanceTest {
+
+    @PersistenceContext
+    EntityManager em;
+
+    @Autowired
+    ItemRepository itemRepository;
+
+    @BeforeEach
+    void setup() throws Exception {
+        // given
+        createBook("책 1", 10000, 100);
+        em.flush();
+
+        /*
+          inheritance joined 인 경우엔 쿼리가 다음과 같이 발생한다.
+          Hibernate: insert into item (name,price,stock_quantity,dtype,item_id) values (?,?,?,'B',?)
+          Hibernate: insert into book (author,isbn,book_id) values (?,?,?)
+         */
+
+    }
+
+    @Test
+    public void 상속관계매핑() {
+        //when
+        em.clear();
+        Item foundItem = itemRepository.findById(1L).get();
+
+        /*
+          inheritance joined 인 경우엔 쿼리가 다음과 같이 발생한다.
+          select i1_0.item_id,i1_0.dtype,i1_0.name,i1_0.price,i1_0.stock_quantity,i1_1.artist,i1_1.etc,i1_2.author,i1_2.isbn,i1_3.actor,i1_3.director
+          from item i1_0
+          left join album i1_1
+            on i1_0.item_id=i1_1.album_id
+          left join book i1_2
+            on i1_0.item_id=i1_2.book_id
+           left join movie i1_3
+            on i1_0.item_id=i1_3.movie_id
+            where i1_0.item_id=?
+         */
+
+        assertEquals("책 1", foundItem.getName());
+    }
+
+    private Book createBook(String name, int price, int stockQuantity) {
+        Book book = new Book();
+        book.setName(name);
+        book.setStockQuantity(stockQuantity);
+        book.setPrice(price);
+        em.persist(book);
+        return book;
+    }
+
+}

--- a/src/test/java/com/example/jpabookshop/service/JpaTest.java
+++ b/src/test/java/com/example/jpabookshop/service/JpaTest.java
@@ -60,6 +60,7 @@ public class JpaTest {
     void testDetachedEntityToMerged() {
         Member member = createMember();
         em1.close(); // 영속성 컨텍스트 1 종료
+        assertTrue(em2.contains(member)); // 책 116, 118 쪽에 나온 내용과 다르다.
 
         member.setName("new_name");
 


### PR DESCRIPTION
- 상속 관계 매핑 테스트 진행
- 조인 전략, 통합 테이블 전략, 단일 테이블 전략 별로 어떻게 insert 및 select 쿼리가 발생하는지 모니터링

## 조인 전략

### 장점
- 테이블이 정규화됨
- 외래 키 참조 무결성 제약 조건의 활용이 가능
- 저장 공간의 효율적 사용

### 단점
- 조회할 때 조인이 많이 사용
- 조회 쿼리가 복잡함
- Insert SQL 이 2번 실행됨


## 단일 테이블 전략

### 장점
- 조인이 필요 없음
- 조회 쿼리가 단순함

### 단점
- 자신 엔티티의 컬럼은 모두 nullable
- 단일 테이블에 모든 것을 저장하므로 테이블이 커진다.

## 구현클래스마다 테이블 전략

### 장점
- 서브 타입을 구분해서 처리
- not null 제약 조건을 사용

### 단점
- 여러 자식 테이블을 함께 조회할 때 성능이 느리다.
- 자식 테이블을 통합해서 쿼리하기 어려움
